### PR TITLE
PROD-224 - Make DecisionResponse Public

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -31,7 +31,7 @@
         <dependency>
             <groupId>org.projectlombok</groupId>
             <artifactId>lombok</artifactId>
-            <version>0.11.0</version>
+            <version>1.14.8</version>
             <scope>compile</scope>
         </dependency>
 

--- a/src/main/java/com/bazaarvoice/cms/client/DecisionResponse.java
+++ b/src/main/java/com/bazaarvoice/cms/client/DecisionResponse.java
@@ -13,19 +13,23 @@ import java.util.Map;
 @Data
 @JsonIgnoreProperties (ignoreUnknown = true)
 public class DecisionResponse {
-    public ContextResponse context;
-    public String submissionUuid;
-    public String decisionAckUuid;
-    public boolean moderationComplete;
-    public Map<String, String> moderationStates = new HashMap<String, String>();
-    public Map<String, DecisionAreaResponse> decisionAreas = new HashMap<String, DecisionAreaResponse>();
-    public Map<String, String> additionalInfo = new HashMap<String, String>();
+    private ContextResponse context;
+    private String submissionUuid;
+    private String decisionAckUuid;
+    private boolean moderationComplete;
+    private Map<String, String> moderationStates = new HashMap<String, String>();
+    private Map<String, DecisionAreaResponse> decisionAreas = new HashMap<String, DecisionAreaResponse>();
+    private Map<String, String> additionalInfo = new HashMap<String, String>();
 
     @Builder
-    public DecisionResponse(ContextResponse contextResponse, String submissionUuid, String decisionAckUuid, boolean moderationComplete, Map<String, String> moderationStates,
-    Map<String, DecisionAreaResponse> decisionAreas,
-    Map<String, String> additionalInfo) {
-        this.context = contextResponse;
+    public DecisionResponse(ContextResponse context,
+                            String submissionUuid,
+                            String decisionAckUuid,
+                            boolean moderationComplete,
+                            Map<String, String> moderationStates,
+                            Map<String, DecisionAreaResponse> decisionAreas,
+                            Map<String, String> additionalInfo) {
+        this.context = context;
         this.submissionUuid = submissionUuid;
         this.decisionAckUuid = decisionAckUuid;
         this.moderationComplete = moderationComplete;
@@ -40,19 +44,29 @@ public class DecisionResponse {
     @Builder
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ContextResponse {
-        public String contentType;
-        public String locale;
-        public String client;
+        private String contentType;
+        private String locale;
+        private String client;
+
+        public ContextResponse(String contentType,
+                               String locale,
+                               String client) {
+            this.contentType = contentType;
+            this.locale = locale;
+            this.client = client;
+        }
+
+        public ContextResponse() {}
     }
 
     @Data
     @Builder
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class DecisionAreaResponse {
-        public String name;
-        public String decision;
-        public List<ModerationResponse> moderationResults = new ArrayList<ModerationResponse>();
-        public Map<String, String> context = new LinkedHashMap<String, String>();
+        private String name;
+        private String decision;
+        private List<ModerationResponse> moderationResults = new ArrayList<ModerationResponse>();
+        private Map<String, String> context = new LinkedHashMap<String, String>();
 
         public boolean isApproved() {
             return "approved".equalsIgnoreCase(decision);
@@ -65,19 +79,49 @@ public class DecisionResponse {
         public boolean isCanceled() {
             return "canceled".equalsIgnoreCase(decision);
         }
+
+        public DecisionAreaResponse(String name,
+                                    String decision,
+                                    List<ModerationResponse> moderationResults,
+                                    Map<String, String> context) {
+            this.name = name;
+            this.decision = decision;
+            this.moderationResults = moderationResults;
+            this.context = context;
+        }
+
+        public DecisionAreaResponse() {}
     }
 
     @Data
     @Builder
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ModerationResponse {
-        public String code;
-        public String codeFullName;
-        public String quotedText;
-        public String quotedField;
-        public int selectionStartIndex;
-        public int selectionEndIndex;
-        public String userComment;
+        private String code;
+        private String codeFullName;
+        private String quotedText;
+        private String quotedField;
+        private int selectionStartIndex;
+        private int selectionEndIndex;
+        private String userComment;
+
+        public ModerationResponse(String code,
+                                  String codeFullName,
+                                  String quotedText,
+                                  String quotedField,
+                                  int selectionStartIndex,
+                                  int selectionEndIndex,
+                                  String userComment) {
+            this.code = code;
+            this.codeFullName = codeFullName;
+            this.quotedText = quotedText;
+            this.quotedField = quotedField;
+            this.selectionStartIndex = selectionStartIndex;
+            this.selectionEndIndex = selectionEndIndex;
+            this.userComment = userComment;
+        }
+
+        public ModerationResponse() {}
     }
 }
 

--- a/src/main/java/com/bazaarvoice/cms/client/DecisionResponse.java
+++ b/src/main/java/com/bazaarvoice/cms/client/DecisionResponse.java
@@ -1,6 +1,8 @@
 package com.bazaarvoice.cms.client;
 
+import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import lombok.experimental.Builder;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
@@ -11,6 +13,9 @@ import java.util.List;
 import java.util.Map;
 
 @Data
+@AllArgsConstructor
+@NoArgsConstructor
+@Builder
 @JsonIgnoreProperties (ignoreUnknown = true)
 public class DecisionResponse {
     private ContextResponse context;
@@ -21,46 +26,21 @@ public class DecisionResponse {
     private Map<String, DecisionAreaResponse> decisionAreas = new HashMap<String, DecisionAreaResponse>();
     private Map<String, String> additionalInfo = new HashMap<String, String>();
 
-    @Builder
-    public DecisionResponse(ContextResponse context,
-                            String submissionUuid,
-                            String decisionAckUuid,
-                            boolean moderationComplete,
-                            Map<String, String> moderationStates,
-                            Map<String, DecisionAreaResponse> decisionAreas,
-                            Map<String, String> additionalInfo) {
-        this.context = context;
-        this.submissionUuid = submissionUuid;
-        this.decisionAckUuid = decisionAckUuid;
-        this.moderationComplete = moderationComplete;
-        this.moderationStates = moderationStates;
-        this.decisionAreas = decisionAreas;
-        this.additionalInfo = additionalInfo;
-    }
-
-    public DecisionResponse() {}
-
     @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
     @Builder
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ContextResponse {
         private String contentType;
         private String locale;
         private String client;
-
-        public ContextResponse(String contentType,
-                               String locale,
-                               String client) {
-            this.contentType = contentType;
-            this.locale = locale;
-            this.client = client;
-        }
-
-        public ContextResponse() {}
     }
 
     @Data
     @Builder
+    @AllArgsConstructor
+    @NoArgsConstructor
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class DecisionAreaResponse {
         private String name;
@@ -79,21 +59,11 @@ public class DecisionResponse {
         public boolean isCanceled() {
             return "canceled".equalsIgnoreCase(decision);
         }
-
-        public DecisionAreaResponse(String name,
-                                    String decision,
-                                    List<ModerationResponse> moderationResults,
-                                    Map<String, String> context) {
-            this.name = name;
-            this.decision = decision;
-            this.moderationResults = moderationResults;
-            this.context = context;
-        }
-
-        public DecisionAreaResponse() {}
     }
 
     @Data
+    @AllArgsConstructor
+    @NoArgsConstructor
     @Builder
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ModerationResponse {
@@ -104,24 +74,6 @@ public class DecisionResponse {
         private int selectionStartIndex;
         private int selectionEndIndex;
         private String userComment;
-
-        public ModerationResponse(String code,
-                                  String codeFullName,
-                                  String quotedText,
-                                  String quotedField,
-                                  int selectionStartIndex,
-                                  int selectionEndIndex,
-                                  String userComment) {
-            this.code = code;
-            this.codeFullName = codeFullName;
-            this.quotedText = quotedText;
-            this.quotedField = quotedField;
-            this.selectionStartIndex = selectionStartIndex;
-            this.selectionEndIndex = selectionEndIndex;
-            this.userComment = userComment;
-        }
-
-        public ModerationResponse() {}
     }
 }
 

--- a/src/main/java/com/bazaarvoice/cms/client/DecisionResponse.java
+++ b/src/main/java/com/bazaarvoice/cms/client/DecisionResponse.java
@@ -1,6 +1,7 @@
 package com.bazaarvoice.cms.client;
 
 import lombok.Data;
+import lombok.experimental.Builder;
 import org.codehaus.jackson.annotate.JsonIgnoreProperties;
 
 import java.util.ArrayList;
@@ -12,29 +13,46 @@ import java.util.Map;
 @Data
 @JsonIgnoreProperties (ignoreUnknown = true)
 public class DecisionResponse {
-    private ContextResponse context;
-    private String submissionUuid;
-    private String decisionAckUuid;
-    private boolean moderationComplete;
-    private Map<String, String> moderationStates = new HashMap<String, String>();
-    private Map<String, DecisionAreaResponse> decisionAreas = new HashMap<String, DecisionAreaResponse>();
-    private Map<String, String> additionalInfo = new HashMap<String, String>();
+    public ContextResponse context;
+    public String submissionUuid;
+    public String decisionAckUuid;
+    public boolean moderationComplete;
+    public Map<String, String> moderationStates = new HashMap<String, String>();
+    public Map<String, DecisionAreaResponse> decisionAreas = new HashMap<String, DecisionAreaResponse>();
+    public Map<String, String> additionalInfo = new HashMap<String, String>();
+
+    @Builder
+    public DecisionResponse(ContextResponse contextResponse, String submissionUuid, String decisionAckUuid, boolean moderationComplete, Map<String, String> moderationStates,
+    Map<String, DecisionAreaResponse> decisionAreas,
+    Map<String, String> additionalInfo) {
+        this.context = contextResponse;
+        this.submissionUuid = submissionUuid;
+        this.decisionAckUuid = decisionAckUuid;
+        this.moderationComplete = moderationComplete;
+        this.moderationStates = moderationStates;
+        this.decisionAreas = decisionAreas;
+        this.additionalInfo = additionalInfo;
+    }
+
+    public DecisionResponse() {}
 
     @Data
+    @Builder
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ContextResponse {
-        private String contentType;
-        private String locale;
-        private String client;
+        public String contentType;
+        public String locale;
+        public String client;
     }
 
     @Data
+    @Builder
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class DecisionAreaResponse {
-        private String name;
-        private String decision;
-        private List<ModerationResponse> moderationResults = new ArrayList<ModerationResponse>();
-        private Map<String, String> context = new LinkedHashMap<String, String>();
+        public String name;
+        public String decision;
+        public List<ModerationResponse> moderationResults = new ArrayList<ModerationResponse>();
+        public Map<String, String> context = new LinkedHashMap<String, String>();
 
         public boolean isApproved() {
             return "approved".equalsIgnoreCase(decision);
@@ -50,15 +68,16 @@ public class DecisionResponse {
     }
 
     @Data
+    @Builder
     @JsonIgnoreProperties(ignoreUnknown = true)
     public static class ModerationResponse {
-        private String code;
-        private String codeFullName;
-        private String quotedText;
-        private String quotedField;
-        private int selectionStartIndex;
-        private int selectionEndIndex;
-        private String userComment;
+        public String code;
+        public String codeFullName;
+        public String quotedText;
+        public String quotedField;
+        public int selectionStartIndex;
+        public int selectionEndIndex;
+        public String userComment;
     }
 }
 


### PR DESCRIPTION
Currently, a decision response cannot be created with a particular context, decision area, etc., because all of its members are private and aren't available to set in a constructor.  This means that services integrating with CMS are unable to write good unit tests that actually test the kinds of responses CMS can return.  I've made DecisionResponse and its subclasses public, and added builder constructors via lombok.  I've also upgraded the version of lombok cms-sdk is using.  It currently uses version 0.11, but builders are only available in 0.12+, and the newest version is 1.14.8, which is what I upgraded to.  Let me know if this is a problem.